### PR TITLE
ci/cd: replace unmaintained actions-rs/toolchain action in CI

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -43,10 +43,7 @@ jobs:
           mkdir -p assets/web_build
           tar -xzvf webview.tar.gz -C assets/web_build
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: 'Install Rust dependencies'
         run: |
           cargo fetch
@@ -76,4 +73,3 @@ jobs:
         with:
           name: linux_x86_64_generic
           path: build/*
-       

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -47,11 +47,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-mingw-w64
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
             toolchain: stable
-            target: x86_64-pc-windows-gnu
-            override: true
+            targets: x86_64-pc-windows-gnu
       - name: 'Install Rust dependencies'
         run: |
           cargo fetch
@@ -78,4 +77,3 @@ jobs:
         with:
           name: windows_x86_64
           path: build/*
-       


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/iwillreku3206/markdown-preview-server/actions/runs/5940715295:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain).