### PR TITLE
add Dependabot configuration file to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# For possible configuration options see:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+# updates for Rust / cargo crates
+- package-ecosystem: "cargo"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 5
+# updates for yarn
+- package-ecosystem: "npm"
+  directory: "/src_web"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 5


### PR DESCRIPTION
Dependabot is bot that can automatically open PRs to update dependencies in order to fix security vulnerabilities.
For more information on that see <https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates>.

This pull request adds a configuration file for Dependabot. That configuration file tells it to take care of updates for Rust crates (that's the `package-ecosystem: "cargo"` section) and Yarn / NPM packages (that's the `package-ecosystem: "npm"` section of the file).